### PR TITLE
fix: rename main→master in CI workflow triggers

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -7,7 +7,7 @@ on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   pull_request:
     branches:
-      - main
+      - master
 
 permissions: read-all
 

--- a/.github/workflows/dev-experience.yml
+++ b/.github/workflows/dev-experience.yml
@@ -8,7 +8,7 @@ on:
       - reopened
       - edited
     branches:
-      - main
+      - master
 
 permissions: read-all
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - master
 
 permissions: read-all
 

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,7 +1,7 @@
 branches:
   - name: "+([0-9])?(.{+([0-9]),x}).x"
     channel: "latest"
-  - name: "main"
+  - name: "master"
     channel: "latest"
   - name: "next"
     channel: "next"


### PR DESCRIPTION
All CI workflows referenced `main` as the target branch, but the repo uses `master`. This caused workflows to never trigger on PRs or pushes.

Also fixed `.releaserc.yml` semantic-release branch config.

**This needs to be merged before any future PRs trigger CI.**